### PR TITLE
Fix code scanning alert no. 1: Insecure randomness

### DIFF
--- a/core/src/main/java/io/xpipe/core/util/AesSecretValue.java
+++ b/core/src/main/java/io/xpipe/core/util/AesSecretValue.java
@@ -55,7 +55,7 @@ public abstract class AesSecretValue extends EncryptedSecretValue {
 
     protected SecretKey getSecretKey(char[] chars) throws InvalidKeySpecException {
         var salt = new byte[SALT_BIT];
-        new Random(AES_KEY_BIT).nextBytes(salt);
+        new SecureRandom().nextBytes(salt);
         KeySpec spec = new PBEKeySpec(chars, salt, getIterationCount(), AES_KEY_BIT);
         return new SecretKeySpec(SECRET_FACTORY.generateSecret(spec).getEncoded(), "AES");
     }


### PR DESCRIPTION
Fixes [https://github.com/sandrociceros-orquestra/xpipe/security/code-scanning/1](https://github.com/sandrociceros-orquestra/xpipe/security/code-scanning/1)

To fix the problem, we need to replace the use of `java.util.Random` with `java.security.SecureRandom`, which is a cryptographically secure random number generator. This change will ensure that the salt values are unpredictable and enhance the security of the derived keys.

- Replace the instantiation of `Random` with `SecureRandom` on line 58.
- Ensure that the rest of the code remains unchanged to maintain existing functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
